### PR TITLE
Github workflow for bikeshed validation

### DIFF
--- a/.github/workflows/build-validate.yml
+++ b/.github/workflows/build-validate.yml
@@ -10,6 +10,9 @@ on:
     branches:
       - development
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   main:
     name: Build and Validate


### PR DESCRIPTION
Added basic build/validate workflow using example from [w3c/spec-prod] docs.

When ready, we can extend this workflow to include publication to github pages, e.g. on release.

[w3c/spec-prod]: https://github.com/w3c/spec-prod