### PR TITLE
Change W3C document type from UD to CG-DRAFT

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2,7 +2,9 @@
 Title: FAIR Data Point
 Shortname: fdp
 Org: W3C
-Status: UD
+Group: fdpcg
+Status: CG-DRAFT
+Level: none
 ED: https://specs.fairdatapoint.org/
 Editor: Luiz Olavo Bonino da Silva Santos, UTwente, https://www.utwente.nl/en/eemcs/scs/
 Editor: Kees Burger, Health-RI, https://www.health-ri.nl/

--- a/index.html
+++ b/index.html
@@ -3,12 +3,12 @@
   <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
   <title>FAIR Data Point</title>
-  <meta content="UD" name="w3c-status">
-  <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-UD" rel="stylesheet">
+  <meta content="CG-DRAFT" name="w3c-status">
+  <link href="https://www.w3.org/StyleSheets/TR/2021/cg-draft" rel="stylesheet">
   <meta content="Bikeshed version 0ef803fdf, updated Tue Jan 6 11:59:39 2026 -0800" name="generator">
   <link href="https://specs.fairdatapoint.org/" rel="canonical">
   <link href="https://www.w3.org/2008/site/images/favicon.ico" rel="icon">
-  <meta content="0e0d42a8cf4807cb4dfc41e770244bcf12d9528f" name="revision">
+  <meta content="df83c98bdb2eeb54112ab0c18f3389dcca7b4f67" name="revision">
   <meta content="dark light" name="color-scheme">
   <link href="https://www.w3.org/StyleSheets/TR/2021/dark.css" media="(prefers-color-scheme: dark)" rel="stylesheet" type="text/css">
 <style>/* Boilerplate: style-autolinks */
@@ -537,8 +537,8 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
 </a>
 </p>
    <h1 class="no-ref p-name" id="title">FAIR Data Point</h1>
-   <p id="w3c-state"><a href="https://www.w3.org/standards/types/#UD">Unofficial Proposal Draft</a>,
-    <time class="dt-updated" datetime="2026-03-12">12 March 2026</time></p>
+   <p id="w3c-state"><a href="https://www.w3.org/standards/types/#CG-DRAFT">Draft Community Group Report</a>,
+    <time class="dt-updated" datetime="2026-04-03">3 April 2026</time></p>
    <details open>
     <summary>More details about this document</summary>
     <div data-fill-with="spec-metadata">


### PR DESCRIPTION
This is now possible because the [FDP community group] is [registered] with bikeshed as `fdpcg`.

TODO:

- [ ] decide on a value for `Level` property

fixes #23 


[FDP community group]: https://www.w3.org/community/fdp/

[registered]: https://github.com/speced/bikeshed-boilerplate/blob/912038f46cbeda27f0d75e9b86672e518422c18a/boilerplate/doctypes.kdl#L112
