### PR TITLE
Fixed inconsistencies in FDP SHACL

### DIFF
--- a/src/rdf/example-metadataservice.ttl
+++ b/src/rdf/example-metadataservice.ttl
@@ -1,18 +1,18 @@
-@prefix dcat:  <http://www.w3.org/ns/dcat#> .
-@prefix dct:   <http://purl.org/dc/terms/> .
-@prefix fdp:   <https://purl.org/fairdatapoint/> .
-@prefix fdp-o: <https://w3id.org/fdp/fdp-o#> .
-@prefix fdp-s: <https://www.purl.org/fairtools/fdp/schema/0.1/> .
-@prefix ldp:   <http://www.w3.org/ns/ldp#> .
-@prefix rdfl:  <http://rdflicense.appspot.com/rdflicense/> .
-@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcat:    <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix fdp:     <https://purl.org/fairdatapoint/> .
+@prefix fdp-o:   <https://w3id.org/fdp/fdp-o#> .
+@prefix fdp-s:   <https://www.purl.org/fairtools/fdp/schema/0.1/> .
+@prefix ldp:     <http://www.w3.org/ns/ldp#> .
+@prefix rdfl:    <http://rdflicense.appspot.com/rdflicense/> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
 
 fdp:app
   a fdp-o:FairDataPoint ;
-  dct:title "Demonstration FAIR Data Point" ;
-  dct:publisher fdp:app#publisher ;
-  dct:license rdfl:cc-by-nc-nd4.0 ;
-  dct:conformsTo fdp-s:fdpMetadata ;
+  dcterms:title "Demonstration FAIR Data Point" ;
+  dcterms:publisher fdp:app#publisher ;
+  dcterms:license rdfl:cc-by-nc-nd4.0 ;
+  dcterms:conformsTo fdp-s:fdpMetadata ;
   dcat:endPointURL fdp:app ;
   fdp-o:metadataIdentifier fdp:app#identifier ;
   fdp-o:metadataIssued "2020-05-29T09:55:08.580Z"^^xsd:dateTime ;
@@ -27,7 +27,7 @@ fdp:app
 
 fdp:app/catalog/
   a ldp:DirectContainer ;
-  dct:title "Catalogs" ;
+  dcterms:title "Catalogs" ;
   ldp:membershipResource fdp:app ;
   ldp:hasMemberRelation fdp-o:metadataCatalog ;
   ldp:contains

--- a/src/rdf/example-metadataservice.ttl
+++ b/src/rdf/example-metadataservice.ttl
@@ -2,7 +2,6 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix fdp:     <https://purl.org/fairdatapoint/> .
 @prefix fdp-o:   <https://w3id.org/fdp/fdp-o#> .
-@prefix fdp-s:   <https://www.purl.org/fairtools/fdp/schema/0.1/> .
 @prefix ldp:     <http://www.w3.org/ns/ldp#> .
 @prefix rdfl:    <http://rdflicense.appspot.com/rdflicense/> .
 @prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
@@ -12,7 +11,7 @@ fdp:app
   dcterms:title "Demonstration FAIR Data Point" ;
   dcterms:publisher fdp:app#publisher ;
   dcterms:license rdfl:cc-by-nc-nd4.0 ;
-  dcterms:conformsTo fdp-s:fdpMetadata ;
+  dcterms:conformsTo fdp:app/profile/77aaad6a-0136-4c6e-88b9-07ffccd0ee4c ;
   dcat:endPointURL fdp:app ;
   fdp-o:metadataIdentifier fdp:app#identifier ;
   fdp-o:metadataIssued "2020-05-29T09:55:08.580Z"^^xsd:dateTime ;

--- a/src/rdf/example-metadataservice.ttl
+++ b/src/rdf/example-metadataservice.ttl
@@ -1,16 +1,16 @@
+@prefix cc:      <https://creativecommons.org/licenses/> .
 @prefix dcat:    <http://www.w3.org/ns/dcat#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix fdp:     <https://purl.org/fairdatapoint/> .
 @prefix fdp-o:   <https://w3id.org/fdp/fdp-o#> .
 @prefix ldp:     <http://www.w3.org/ns/ldp#> .
-@prefix rdfl:    <http://rdflicense.appspot.com/rdflicense/> .
 @prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
 
 fdp:app
   a fdp-o:FairDataPoint ;
   dcterms:title "Demonstration FAIR Data Point" ;
   dcterms:publisher fdp:app#publisher ;
-  dcterms:license rdfl:cc-by-nc-nd4.0 ;
+  dcterms:license cc:by-nc-nd/4.0/rdf ;
   dcterms:conformsTo fdp:app/profile/77aaad6a-0136-4c6e-88b9-07ffccd0ee4c ;
   dcat:endPointURL fdp:app ;
   fdp-o:metadataIdentifier fdp:app#identifier ;

--- a/src/rdf/example-metadataservice.ttl
+++ b/src/rdf/example-metadataservice.ttl
@@ -1,30 +1,38 @@
+@prefix dcat:  <http://www.w3.org/ns/dcat#> .
 @prefix dct:   <http://purl.org/dc/terms/> .
+@prefix fdp:   <https://purl.org/fairdatapoint/> .
 @prefix fdp-o: <https://w3id.org/fdp/fdp-o#> .
+@prefix fdp-s: <https://www.purl.org/fairtools/fdp/schema/0.1/> .
 @prefix ldp:   <http://www.w3.org/ns/ldp#> .
-<https://fairdatapoint.org/app> a fdp-o:FairDataPoint
-  dct:title "Demonstration FAIR Data Point";
-  dct:conformsTo <https://www.purl.org/fairtools/fdp/schema/0.1/fdpMetadata>;
-  dct:description "This FAIR Data Point deployment is used for demonstration of the application and to allow the navigation through its metadata content. The metadata presented here is also for demonstration purposes only and not necessarily describe properly their related resources.";
-  dct:hasVersion "1.0" ;
-  dct:license <http://rdflicense.appspot.com/rdflicense/cc-by-nc-nd4.0>;
-  dct:publisher <https://purl.org/fairdatapoint/app#publisher>;
-  fdp-o:metadataIdentifier <https://purl.org/fairdatapoint/app#identifier>;
-  fdp-o:metadataIssued "2020-05-29T09:55:08.580Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
-  fdp-o:metadataModified "2020-09-30T11:17:43.008Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
-  fdp-o:metadataCatalog
-    <https://purl.org/fairdatapoint/app/catalog/3dde263d-0a7c-4f2a-9813-ccb3a51f70a8>,
-    <https://purl.org/fairdatapoint/app/catalog/508d3c96-8106-49d2-910c-13706aca75e3> ,
-    <https://purl.org/fairdatapoint/app/catalog/6e43c568-c6fa-41c8-a88a-7ee4c85035af> ,
-    <https://purl.org/fairdatapoint/app/catalog/a46aa445-3be0-4db8-8968-3338d1061a47> ,
-    <https://purl.org/fairdatapoint/app/catalog/a91d3db7-fe83-4de1-b678-fe1b0c82f2f1> .
+@prefix rdfl:  <http://rdflicense.appspot.com/rdflicense/> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
 
-<https://purl.org/fairdatapoint/app/catalog/> a ldp:DirectContainer ;
+fdp:app
+  a fdp-o:FairDataPoint ;
+  dct:title "Demonstration FAIR Data Point" ;
+  dct:publisher fdp:app#publisher ;
+  dct:license rdfl:cc-by-nc-nd4.0 ;
+  dct:conformsTo fdp-s:fdpMetadata ;
+  dcat:endPointURL fdp:app ;
+  fdp-o:metadataIdentifier fdp:app#identifier ;
+  fdp-o:metadataIssued "2020-05-29T09:55:08.580Z"^^xsd:dateTime ;
+  fdp-o:metadataModified "2020-09-30T11:17:43.008Z"^^xsd:dateTime ;
+  fdp-o:conformsToFdpSpec "1.2" ;
+  fdp-o:metadataCatalog
+    fdp:app/catalog/3dde263d-0a7c-4f2a-9813-ccb3a51f70a8 ,
+    fdp:app/catalog/508d3c96-8106-49d2-910c-13706aca75e3 ,
+    fdp:app/catalog/6e43c568-c6fa-41c8-a88a-7ee4c85035af ,
+    fdp:app/catalog/a46aa445-3be0-4db8-8968-3338d1061a47 ,
+    fdp:app/catalog/a91d3db7-fe83-4de1-b678-fe1b0c82f2f1 .
+
+fdp:app/catalog/
+  a ldp:DirectContainer ;
   dct:title "Catalogs" ;
-  ldp:membershipResource <https://fairdatapoint.org/app> ;
+  ldp:membershipResource fdp:app ;
   ldp:hasMemberRelation fdp-o:metadataCatalog ;
   ldp:contains
-    <https://purl.org/fairdatapoint/app/catalog/3dde263d-0a7c-4f2a-9813-ccb3a51f70a8> ,
-    <https://purl.org/fairdatapoint/app/catalog/508d3c96-8106-49d2-910c-13706aca75e3> ,
-    <https://purl.org/fairdatapoint/app/catalog/6e43c568-c6fa-41c8-a88a-7ee4c85035af> ,
-    <https://purl.org/fairdatapoint/app/catalog/a46aa445-3be0-4db8-8968-3338d1061a47> ,
-    <https://purl.org/fairdatapoint/app/catalog/a91d3db7-fe83-4de1-b678-fe1b0c82f2f1> .
+    fdp:app/catalog/3dde263d-0a7c-4f2a-9813-ccb3a51f70a8 ,
+    fdp:app/catalog/508d3c96-8106-49d2-910c-13706aca75e3 ,
+    fdp:app/catalog/6e43c568-c6fa-41c8-a88a-7ee4c85035af ,
+    fdp:app/catalog/a46aa445-3be0-4db8-8968-3338d1061a47 ,
+    fdp:app/catalog/a91d3db7-fe83-4de1-b678-fe1b0c82f2f1 .

--- a/src/rdf/example-metadataservice.ttl
+++ b/src/rdf/example-metadataservice.ttl
@@ -12,7 +12,7 @@ fdp:app
   dcterms:publisher fdp:app#publisher ;
   dcterms:license cc:by-nc-nd/4.0/rdf ;
   dcterms:conformsTo fdp:app/profile/77aaad6a-0136-4c6e-88b9-07ffccd0ee4c ;
-  dcat:endPointURL fdp:app ;
+  dcat:endpointURL fdp:app ;
   fdp-o:metadataIdentifier fdp:app#identifier ;
   fdp-o:metadataIssued "2020-05-29T09:55:08.580Z"^^xsd:dateTime ;
   fdp-o:metadataModified "2020-09-30T11:17:43.008Z"^^xsd:dateTime ;

--- a/src/rdf/shacl-catalog.ttl
+++ b/src/rdf/shacl-catalog.ttl
@@ -51,7 +51,7 @@
     sh:path dcat:theme ;
     sh:nodeKind sh:IRI ;
   ], [
-    sh:path dcat:endPointURL ;
+    sh:path dcat:endpointURL ;
     sh:nodeKind sh:IRI ;
     sh:maxCount 1 ;
     sh:minCount 1 ;

--- a/src/rdf/shacl-fdp.ttl
+++ b/src/rdf/shacl-fdp.ttl
@@ -67,20 +67,24 @@
     sh:minCount 1 ;
   ], [
     sh:path fdp-o:metadataIssued ;
+    sh:nodeKind sh:Literal ;
     sh:datatype xsd:dateTime ;
     sh:maxCount 1 ;
     sh:minCount 1 ;
   ], [
     sh:path fdp-o:metadataModified ;
+    sh:nodeKind sh:Literal ;
     sh:datatype xsd:dateTime ;
     sh:maxCount 1 ;
     sh:minCount 1 ;
   ], [
     sh:path fdp-o:startDate ;
+    sh:nodeKind sh:Literal ;
     sh:datatype xsd:date ;
     sh:maxCount 1 ;
   ], [
     sh:path fdp-o:endDate ;
+    sh:nodeKind sh:Literal ;
     sh:datatype xsd:date ;
     sh:maxCount 1 ;
   ], [

--- a/src/rdf/shacl-fdp.ttl
+++ b/src/rdf/shacl-fdp.ttl
@@ -61,14 +61,6 @@
     sh:path dcat:endPointDescription ;
     sh:nodeKind sh:IRI ;
   ], [
-    sh:path fdp-o:startDate ;
-    sh:datatype xsd:date ;
-    sh:maxCount 1 ;
-  ], [
-    sh:path fdp-o:endDate ;
-    sh:datatype xsd:date ;
-    sh:maxCount 1 ;
-  ], [
     sh:path fdp-o:metadataIdentifier ;
     sh:nodeKind sh:IRI ;
     sh:maxCount 1 ;
@@ -83,6 +75,14 @@
     sh:datatype xsd:dateTime ;
     sh:maxCount 1 ;
     sh:minCount 1 ;
+  ], [
+    sh:path fdp-o:startDate ;
+    sh:datatype xsd:date ;
+    sh:maxCount 1 ;
+  ], [
+    sh:path fdp-o:endDate ;
+    sh:datatype xsd:date ;
+    sh:maxCount 1 ;
   ], [
     sh:path dct:conformsToFdpSpec ;
     sh:nodeKind sh:IRI ;

--- a/src/rdf/shacl-fdp.ttl
+++ b/src/rdf/shacl-fdp.ttl
@@ -95,7 +95,7 @@
     sh:nodeKind sh:Literal ;
     sh:maxCount 1 ;
   ], [
-    sh:path dct:conformsToFdpSpec ;
+    sh:path fdp-o:conformsToFdpSpec ;
     sh:nodeKind sh:IRI ;
     sh:maxCount 1;
     sh:minCount 1;

--- a/src/rdf/shacl-fdp.ttl
+++ b/src/rdf/shacl-fdp.ttl
@@ -58,6 +58,9 @@
     sh:maxCount 1 ;
     sh:minCount 1 ;
   ], [
+    sh:path dcat:endPointDescription ;
+    sh:nodeKind sh:IRI ;
+  ], [
     sh:path fdp-o:startDate ;
     sh:datatype xsd:date ;
     sh:maxCount 1 ;

--- a/src/rdf/shacl-fdp.ttl
+++ b/src/rdf/shacl-fdp.ttl
@@ -98,7 +98,6 @@
   ], [
     sh:path fdp-o:metadataCatalog ;
     sh:node :CatalogShape ;
-    sh:minCount 1;
   ].
 
 :AgentShape a sh:NodeShape ;

--- a/src/rdf/shacl-fdp.ttl
+++ b/src/rdf/shacl-fdp.ttl
@@ -41,7 +41,7 @@
     sh:nodeKind sh:IRI ;
   ], [
     sh:path dcat:contactPoint ;
-    sh:node sh:ContactPointShape ;
+    sh:node :ContactPointShape ;
   ], [
     sh:path dcat:keyword ;
     sh:nodeKind sh:Literal ;

--- a/src/rdf/shacl-fdp.ttl
+++ b/src/rdf/shacl-fdp.ttl
@@ -84,6 +84,9 @@
     sh:datatype xsd:date ;
     sh:maxCount 1 ;
   ], [
+    sh:path fdp-o:uiLanguage ;
+    sh:nodeKind sh:IRI ;
+  ], [
     sh:path dct:conformsToFdpSpec ;
     sh:nodeKind sh:IRI ;
     sh:maxCount 1;

--- a/src/rdf/shacl-fdp.ttl
+++ b/src/rdf/shacl-fdp.ttl
@@ -87,6 +87,10 @@
     sh:path fdp-o:uiLanguage ;
     sh:nodeKind sh:IRI ;
   ], [
+    sh:path fdp-o:hasSoftwareVersion ;
+    sh:nodeKind sh:Literal ;
+    sh:maxCount 1 ;
+  ], [
     sh:path dct:conformsToFdpSpec ;
     sh:nodeKind sh:IRI ;
     sh:maxCount 1;

--- a/src/rdf/shacl-fdp.ttl
+++ b/src/rdf/shacl-fdp.ttl
@@ -71,7 +71,7 @@
     sh:maxCount 1 ;
     sh:minCount 1 ;
   ], [
-    sh:path fdp-o:metadataIdentifier ;
+    sh:path fdp-o:metadataModified ;
     sh:datatype xsd:dateTime ;
     sh:maxCount 1 ;
     sh:minCount 1 ;

--- a/src/rdf/shacl-fdp.ttl
+++ b/src/rdf/shacl-fdp.ttl
@@ -54,7 +54,7 @@
     sh:maxCount 1 ;
     sh:minCount 1 ;
   ], [
-    sh:path dcat:endPointDescription ;
+    sh:path dcat:endpointDescription ;
     sh:nodeKind sh:IRI ;
   ], [
     sh:path fdp-o:metadataIdentifier ;

--- a/src/rdf/shacl-fdp.ttl
+++ b/src/rdf/shacl-fdp.ttl
@@ -14,10 +14,6 @@
     sh:nodeKind sh:Literal ;
     sh:minCount 1 ;
   ], [
-    sh:path dct:hasVersion ;
-    sh:nodeKind sh:Literal ;
-    sh:maxCount ;
-  ], [
     sh:path dct:description ;
     sh:nodeKind sh:Literal ;
   ], [

--- a/src/rdf/shacl-fdp.ttl
+++ b/src/rdf/shacl-fdp.ttl
@@ -1,43 +1,43 @@
-@prefix      : <http://fairdatapoint.org/> .
-@prefix  dcat: <http://www.w3.org/ns/dcat#> .
-@prefix   dct: <http://purl.org/dc/terms/> .
-@prefix fdp-o: <https://w3id.org/fdp/fdp-o#> .
-@prefix  foaf: <http://xmlns.com/foaf/0.1/> .
-@prefix   ldp: <http://www.w3.org/ns/ldp#> .
-@prefix    sh: <http://www.w3.org/ns/shacl#> .
-@prefix   xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix :        <http://fairdatapoint.org/> .
+@prefix dcat:    <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix fdp-o:   <https://w3id.org/fdp/fdp-o#> .
+@prefix foaf:    <http://xmlns.com/foaf/0.1/> .
+@prefix ldp:     <http://www.w3.org/ns/ldp#> .
+@prefix sh:      <http://www.w3.org/ns/shacl#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
 
 :FAIRDataPointShape a sh:NodeShape ;
   sh:targetClass fdp-o:FAIRDataPoint ;
   sh:property [
-    sh:path dct:title ;
+    sh:path dcterms:title ;
     sh:nodeKind sh:Literal ;
     sh:minCount 1 ;
   ], [
-    sh:path dct:description ;
+    sh:path dcterms:description ;
     sh:nodeKind sh:Literal ;
   ], [
-    sh:path dct:publisher ;
+    sh:path dcterms:publisher ;
     sh:node :AgentShape ;
     sh:minCount 1;
   ], [
-    sh:path dct:language ;
+    sh:path dcterms:language ;
     sh:nodeKind sh:IRI ;
   ], [
-    sh:path dct:license ;
+    sh:path dcterms:license ;
     sh:nodeKind sh:IRI ;
     sh:minCount 1;
     sh:maxCount 1 ;
   ], [
-    sh:path dct:conformsTo ;
+    sh:path dcterms:conformsTo ;
     sh:nodeKind sh:IRI ;
     sh:maxCount 1;
     sh:minCount 1;
   ], [
-    sh:path dct:rights ;
+    sh:path dcterms:rights ;
     sh:nodeKind sh:IRI ;
   ], [
-    sh:path dct:accessRights ;
+    sh:path dcterms:accessRights ;
     sh:nodeKind sh:IRI ;
   ], [
     sh:path dcat:contactPoint ;
@@ -123,7 +123,7 @@
   sh:property [
     sh:name "title" ;
     sh:description "Name identifying the member resources" ;
-    sh:path dct:title ;
+    sh:path dcterms:title ;
     sh:nodeKind sh:Literal ;
     sh:minCount 1 ;
     sh:uniqueLang true ;

--- a/src/rdf/shacl-fdp.ttl
+++ b/src/rdf/shacl-fdp.ttl
@@ -17,10 +17,6 @@
     sh:path dct:description ;
     sh:nodeKind sh:Literal ;
   ], [
-    sh:path fdp-o:metadataCatalog ;
-    sh:node :CatalogShape ;
-    sh:minCount 1;
-  ], [
     sh:path dct:publisher ;
     sh:node :AgentShape ;
     sh:minCount 1;
@@ -98,6 +94,10 @@
     sh:path fdp-o:conformsToFdpSpec ;
     sh:nodeKind sh:IRI ;
     sh:maxCount 1;
+    sh:minCount 1;
+  ], [
+    sh:path fdp-o:metadataCatalog ;
+    sh:node :CatalogShape ;
     sh:minCount 1;
   ].
 

--- a/src/rdf/shacl-fdp.ttl
+++ b/src/rdf/shacl-fdp.ttl
@@ -49,7 +49,7 @@
     sh:path dcat:theme ;
     sh:nodeKind sh:IRI ;
   ], [
-    sh:path dcat:endPointURL ;
+    sh:path dcat:endpointURL ;
     sh:nodeKind sh:IRI ;
     sh:maxCount 1 ;
     sh:minCount 1 ;

--- a/src/tables/table-fdp-metadata.html
+++ b/src/tables/table-fdp-metadata.html
@@ -101,7 +101,7 @@
         </tr>
         <tr>
             <td></td>
-            <td>dcat:endPointURL</td>
+            <td>dcat:endpointURL</td>
             <td>IRI</td>
             <td>1</td>
             <td>The URL of the FDP API endpoint.</td>

--- a/src/tables/table-fdp-metadata.html
+++ b/src/tables/table-fdp-metadata.html
@@ -176,7 +176,7 @@
             <td></td>
             <td>fdp-o:metadataCatalog</td>
             <td></td>
-            <td>1..*</td>
+            <td>0..*</td>
             <td>This relation points to a <code>dcat:Catalog</code>.</td>
         </tr>
     </tbody>

--- a/src/tables/table-fdp-metadata.html
+++ b/src/tables/table-fdp-metadata.html
@@ -20,56 +20,56 @@
         </tr>
         <tr>
             <td>DC terms</td>
-            <td>dct:title</td>
+            <td>dcterms:title</td>
             <td>String</td>
             <td>1..*</td>
             <td>Name of the FAIR Data Point with the language tag.</td>
         </tr>
         <tr>
             <td></td>
-            <td>dct:description</td>
+            <td>dcterms:description</td>
             <td>String</td>
             <td>0..*</td>
             <td>Description of the FAIR Data Point with the language tag.</td>
         </tr>
         <tr>
             <td></td>
-            <td>dct:publisher</td>
+            <td>dcterms:publisher</td>
             <td><code>foaf:Agent</code></td>
             <td>1..*</td>
             <td>The entity or entities (person or organization) responsible for the FAIR Data Point.</td>
         </tr>
         <tr>
             <td></td>
-            <td>dct:language</td>
+            <td>dcterms:language</td>
             <td>IRI</td>
             <td>0..*</td>
             <td>The language(s) used in the metadata record.</td>
         </tr>
         <tr>
             <td></td>
-            <td>dct:license</td>
+            <td>dcterms:license</td>
             <td>IRI</td>
             <td>1</td>
             <td>The reference to the usage license of the FAIR Data Point.</td>
         </tr>
         <tr>
             <td></td>
-            <td>dct:conformsTo</td>
+            <td>dcterms:conformsTo</td>
             <td>IRI</td>
             <td>1</td>
             <td>This property points to a profile that contains the specification of the FAIR Data Point's metadata schema (in <code>SHACL</code>).</td>
         </tr>
         <tr>
             <td></td>
-            <td>dct:rights</td>
+            <td>dcterms:rights</td>
             <td>IRI</td>
             <td>0..*</td>
             <td></td>
         </tr>
         <tr>
             <td></td>
-            <td>dct:accessRights</td>
+            <td>dcterms:accessRights</td>
             <td>IRI</td>
             <td>0..*</td>
             <td></td>
@@ -156,7 +156,7 @@
             <td>fdp-o:uiLanguage</td>
             <td>IRI</td>
             <td>0..*</td>
-            <td>The user interface language(s) of the FAIR Data Point, which is different from the <code>dcat:Resource</code> property of <code>dct:language</code> that relates to the language of the metadata record.</td>
+            <td>The user interface language(s) of the FAIR Data Point, which is different from the <code>dcat:Resource</code> property of <code>dcterms:language</code> that relates to the language of the metadata record.</td>
         </tr>
         <tr>
             <td></td>

--- a/src/tables/table-fdp-metadata.html
+++ b/src/tables/table-fdp-metadata.html
@@ -172,5 +172,12 @@
             <td>1</td>
             <td>The relation should point to a URI that contains the version of the FDP specifications which this instance of the FDP conforms to.</td>
         </tr>
+        <tr>
+            <td></td>
+            <td>fdp-o:metadataCatalog</td>
+            <td></td>
+            <td>1..*</td>
+            <td>This relation points to a <code>dcat:Catalog</code>.</td>
+        </tr>
     </tbody>
 </table>

--- a/src/tables/table-fdp-metadata.html
+++ b/src/tables/table-fdp-metadata.html
@@ -108,7 +108,7 @@
         </tr>
         <tr>
             <td></td>
-            <td>dcat:endPointDescription</td>
+            <td>dcat:endpointDescription</td>
             <td>IRI</td>
             <td>0..*</td>
             <td>

--- a/src/tables/table-navigation-information.html
+++ b/src/tables/table-navigation-information.html
@@ -22,7 +22,7 @@
         </tr>
         <tr>
             <td>DC terms</td>
-            <td>dct:title</td>
+            <td>dcterms:title</td>
             <td>String</td>
             <td>1..*</td>
             <td>Name of the container.</td>

--- a/src/tables/table-navigation-information.html
+++ b/src/tables/table-navigation-information.html
@@ -29,13 +29,12 @@
         </tr>
         <tr>
             <td>LDP</td>
-            <td>ldp:contains</td>
+            <td>ldp:membershipResource</td>
             <td><code>IRI</code></td>
-            <td>0..*</td>
+            <td>1</td>
             <td>
-                Identifier of the resources contained in this container.
-                In this case, the identifiers of the catalogs available in this FAIR Data Point.
-                The object of this property <em class="rdc2119">MUST</em> be an instance of <code>dcat:Catalog</code> or a sub-class of it.
+                This relation points to the identifier of the FAIR Data Point that is related to this container.
+                The object of this property <em class="rdc2119">MUST</em> be an instance of <code>fdp-o:FAIRDataPoint</code>.
             </td>
         </tr>
         <tr>
@@ -50,12 +49,13 @@
         </tr>
         <tr>
             <td>LDP</td>
-            <td>ldp:membershipResource</td>
+            <td>ldp:contains</td>
             <td><code>IRI</code></td>
-            <td>1</td>
+            <td>0..*</td>
             <td>
-                This relation points to the identifier of the FAIR Data Point that is related to this container.
-                The object of this property <em class="rdc2119">MUST</em> be an instance of <code>fdp-o:FAIRDataPoint</code>.
+                Identifier of the resources contained in this container.
+                In this case, the identifiers of the catalogs available in this FAIR Data Point.
+                The object of this property <em class="rdc2119">MUST</em> be an instance of <code>dcat:Catalog</code> or a sub-class of it.
             </td>
         </tr>
     </tbody>

--- a/src/tables/table-navigation-information.html
+++ b/src/tables/table-navigation-information.html
@@ -31,7 +31,7 @@
             <td>LDP</td>
             <td>ldp:contains</td>
             <td><code>IRI</code></td>
-            <td>1..*</td>
+            <td>0..*</td>
             <td>
                 Identifier of the resources contained in this container.
                 In this case, the identifiers of the catalogs available in this FAIR Data Point.


### PR DESCRIPTION
Fixed inconsistencies between FDP SHACL file and corresponding tables.
See commit messages below for details.

fixes #30 

TODO:

- [ ] should we replace the `http://fairdatapoint.org` by some persistent url, and let that persistent url point to the [github directory containing the raw ttl files]?
- [ ] should we use [empty URIrefs], with fragment ids for the shapes, as in `<#FAIRDataPointShape>` and so on?

[empty URIrefs]: https://www.w3.org/2001/09/rdfprimer/section2.html#identifiers
[github directory containing the raw ttl files]: https://raw.githubusercontent.com/fdp-specs/fdp-specs.github.io/refs/heads/development/src/rdf/