### PR TITLE
Fixed inconsistencies in Catalog SHACL

### DIFF
--- a/src/rdf/shacl-catalog.ttl
+++ b/src/rdf/shacl-catalog.ttl
@@ -53,7 +53,7 @@
     sh:nodeKind sh:IRI ;
   ], [
     sh:path dcterms:hasPart ;
-    sh:node sh:ContactPointShape ;
+    sh:class dcat:Resource ;
   ], [
     sh:path dcat:keyword ;
     sh:nodeKind sh:Literal ;

--- a/src/rdf/shacl-catalog.ttl
+++ b/src/rdf/shacl-catalog.ttl
@@ -79,6 +79,9 @@
     sh:datatype xsd:dateTime ;
     sh:maxCount 1 ;
     sh:minCount 1 ;
+  ], [
+    sh:path foaf:homepage ;
+    sh:nodeKind sh:IRI ;
   ].
 
 :AgentShape a sh:NodeShape ;

--- a/src/rdf/shacl-catalog.ttl
+++ b/src/rdf/shacl-catalog.ttl
@@ -60,6 +60,11 @@
     sh:maxCount 1 ;
     sh:minCount 1 ;
   ], [
+    sh:path dcat:themeTaxonomy ;
+    sh:nodeKind sh:IRI ;
+    sh:maxCount 1 ;
+    sh:minCount 1 ;
+  ], [
     sh:path dcat:keyword ;
     sh:nodeKind sh:Literal ;
   ], [

--- a/src/rdf/shacl-catalog.ttl
+++ b/src/rdf/shacl-catalog.ttl
@@ -1,48 +1,48 @@
-@prefix     : <http://fairdatapoint.org/> .
-@prefix dcat: <http://www.w3.org/ns/dcat#> .
-@prefix  dct: <http://purl.org/dc/terms/> .
-@prefix foaf: <http://xmlns.com/foaf/0.1/> .
-@prefix   sh: <http://www.w3.org/ns/shacl#> .
-@prefix  xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix :        <http://fairdatapoint.org/> .
+@prefix dcat:    <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf:    <http://xmlns.com/foaf/0.1/> .
+@prefix sh:      <http://www.w3.org/ns/shacl#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
 
 :CatalogShape a sh:NodeShape ;
   sh:targetClass dcat:Catalog ;
   sh:property [
-    sh:path dct:title ;
+    sh:path dcterms:title ;
     sh:nodeKind sh:Literal ;
     sh:minCount 1 ;
   ], [
-    sh:path dct:hasVersion ;
+    sh:path dcterms:hasVersion ;
     sh:nodeKind sh:Literal ;
     sh:maxCount ;
   ], [
-    sh:path dct:description ;
+    sh:path dcterms:description ;
     sh:nodeKind sh:Literal ;
   ], [
-    sh:path dct:publisher ;
+    sh:path dcterms:publisher ;
     sh:node :AgentShape ;
     sh:minCount 1;
   ], [
-    sh:path dct:language ;
+    sh:path dcterms:language ;
     sh:nodeKind sh:IRI ;
   ], [
-    sh:path dct:license ;
+    sh:path dcterms:license ;
     sh:nodeKind sh:IRI ;
     sh:minCount 1;
     sh:maxCount 1 ;
   ], [
-    sh:path dct:conformsTo ;
+    sh:path dcterms:conformsTo ;
     sh:nodeKind sh:IRI ;
     sh:maxCount 1;
     sh:minCount 1;
   ], [
-    sh:path dct:rights ;
+    sh:path dcterms:rights ;
     sh:nodeKind sh:IRI ;
   ], [
-    sh:path dct:accessRights ;
+    sh:path dcterms:accessRights ;
     sh:nodeKind sh:IRI ;
   ], [
-    sh:path dct:hasPart ;
+    sh:path dcterms:hasPart ;
     sh:node sh:ContactPointShape ;
   ], [
     sh:path dcat:keyword ;

--- a/src/rdf/shacl-catalog.ttl
+++ b/src/rdf/shacl-catalog.ttl
@@ -65,25 +65,6 @@
     sh:maxCount 1 ;
     sh:minCount 1 ;
   ], [
-    sh:path dcat:keyword ;
-    sh:nodeKind sh:Literal ;
-  ], [
-    sh:path dcat:theme ;
-    sh:nodeKind sh:IRI ;
-  ], [
-    sh:path dcat:endPointURL ;
-    sh:nodeKind sh:IRI ;
-    sh:maxCount 1 ;
-    sh:minCount 1 ;
-  ], [
-    sh:path fdp-o:startDate ;
-    sh:datatype xsd:date ;
-    sh:maxCount 1 ;
-  ], [
-    sh:path fdp-o:endDate ;
-    sh:datatype xsd:date ;
-    sh:maxCount 1 ;
-  ], [
     sh:path fdp-o:metadataIdentifier ;
     sh:nodeKind sh:IRI ;
     sh:maxCount 1 ;

--- a/src/rdf/shacl-catalog.ttl
+++ b/src/rdf/shacl-catalog.ttl
@@ -75,7 +75,7 @@
     sh:maxCount 1 ;
     sh:minCount 1 ;
   ], [
-    sh:path fdp-o:metadataIdentifier ;
+    sh:path fdp-o:metadataModified ;
     sh:datatype xsd:dateTime ;
     sh:maxCount 1 ;
     sh:minCount 1 ;

--- a/src/rdf/shacl-catalog.ttl
+++ b/src/rdf/shacl-catalog.ttl
@@ -31,6 +31,16 @@
     sh:minCount 1;
     sh:maxCount 1 ;
   ], [
+    sh:path dcterms:issued ;
+    sh:nodeKind sh:Literal ;
+    sh:datatype xsd:dateTime ;
+    sh:maxCount 1 ;
+  ], [
+    sh:path dcterms:modified ;
+    sh:nodeKind sh:Literal ;
+    sh:datatype xsd:dateTime ;
+    sh:maxCount 1 ;
+  ], [
     sh:path dcterms:conformsTo ;
     sh:nodeKind sh:IRI ;
     sh:maxCount 1;

--- a/src/rdf/shacl-catalog.ttl
+++ b/src/rdf/shacl-catalog.ttl
@@ -92,12 +92,3 @@
     sh:maxCount 1 ;
     sh:minCount 1 ;
   ].
-
-:ContactPointShape a sh:NodeShape ;
-  sh:targetClass vcard:Kind ;
-  sh:property [
-    sh:path vcard:hasEmail ;
-    sh:nodeKind sh:Literal ;
-    sh:maxCount 1 ;
-    sh:minCount 1 ;
-  ].

--- a/src/rdf/shacl-catalog.ttl
+++ b/src/rdf/shacl-catalog.ttl
@@ -14,7 +14,7 @@
   ], [
     sh:path dcterms:hasVersion ;
     sh:nodeKind sh:Literal ;
-    sh:maxCount ;
+    sh:maxCount 1;
   ], [
     sh:path dcterms:description ;
     sh:nodeKind sh:Literal ;

--- a/src/rdf/shacl-catalog.ttl
+++ b/src/rdf/shacl-catalog.ttl
@@ -55,6 +55,11 @@
     sh:path dcterms:hasPart ;
     sh:class dcat:Resource ;
   ], [
+    sh:path dcterms:isPartOf ;
+    sh:nodeKind sh:IRI ;
+    sh:maxCount 1 ;
+    sh:minCount 1 ;
+  ], [
     sh:path dcat:keyword ;
     sh:nodeKind sh:Literal ;
   ], [

--- a/src/tables/table-catalog-metadata.html
+++ b/src/tables/table-catalog-metadata.html
@@ -22,84 +22,84 @@
         </tr>
         <tr>
             <td>DC terms</td>
-            <td>dct:title</td>
+            <td>dcterms:title</td>
             <td>String</td>
             <td>1..*</td>
             <td>Name of the catalog with the language tag.</td>
         </tr>
         <tr>
             <td></td>
-            <td>dct:hasVersion</td>
+            <td>dcterms:hasVersion</td>
             <td>String</td>
             <td>0..1</td>
             <td>Version of the catalog.</td>
         </tr>
         <tr>
             <td></td>
-            <td>dct:description</td>
+            <td>dcterms:description</td>
             <td>String</td>
             <td>0..*</td>
             <td>Description of the catalog with the language tag.</td>
         </tr>
         <tr>
             <td></td>
-            <td>dct:publisher</td>
+            <td>dcterms:publisher</td>
             <td><code>foaf:Agent</code></td>
             <td>1..*</td>
             <td>The entity or entities (person or organization) responsible for the catalog.</td>
         </tr>
         <tr>
             <td></td>
-            <td>dct:language</td>
+            <td>dcterms:language</td>
             <td>IRI</td>
             <td>0..*</td>
             <td>The language(s) used in the catalog.</td>
         </tr>
         <tr>
             <td></td>
-            <td>dct:license</td>
+            <td>dcterms:license</td>
             <td>IRI</td>
             <td>1</td>
             <td>The reference to the usage license of the catalog.</td>
         </tr>
         <tr>
             <td></td>
-            <td>dct:issued</td>
+            <td>dcterms:issued</td>
             <td>DateTime</td>
             <td>0..1</td>
             <td>The creation date of the catalog metadata record.</td>
         </tr>
         <tr>
             <td></td>
-            <td>dct:modified</td>
+            <td>dcterms:modified</td>
             <td>DateTime</td>
             <td>0..1</td>
             <td>The last modified date of the catalog metadata record.</td>
         </tr>
         <tr>
             <td></td>
-            <td>dct:conformsTo</td>
+            <td>dcterms:conformsTo</td>
             <td>IRI</td>
             <td>1</td>
             <td>The specification of the catalog metadata schema (in <code>SHACL</code>).</td>
         </tr>
         <tr>
             <td></td>
-            <td>dct:rights</td>
+            <td>dcterms:rights</td>
             <td>IRI</td>
             <td>0..*</td>
             <td></td>
         </tr>
         <tr>
             <td></td>
-            <td>dct:accessRights</td>
+            <td>dcterms:accessRights</td>
             <td>IRI</td>
             <td>0..*</td>
             <td></td>
         </tr>
         <tr>
             <td></td>
-            <td>dct:hasPart</td>
+            <td>dcterms:hasPart</td>
             <td>IRI</td>
             <td>1..*</td>
             <td>
@@ -110,7 +110,7 @@
         </tr>
         <tr>
             <td></td>
-            <td>dct:isPartOf</td>
+            <td>dcterms:isPartOf</td>
             <td>IRI</td>
             <td>1</td>
             <td>

--- a/src/tables/table-catalog-metadata.html
+++ b/src/tables/table-catalog-metadata.html
@@ -101,7 +101,7 @@
             <td></td>
             <td>dcterms:hasPart</td>
             <td>IRI</td>
-            <td>1..*</td>
+            <td>0..*</td>
             <td>
                 The relation between the catalog and its items.
                 This is the most general predicate for membership of a catalog.


### PR DESCRIPTION
SHACL problems fixed:

- fixed missing max count for `dcterms:hasVersion`
- added missing `dcterms:issued` and `dcterms:modified`
- fixed target for `dcterms:hasPart`
- changed minimal cardinality for `dcterms:hasPart` to `0` (to allow empty catalogs)
- added missing `dcterms:isPartOf`
- added missing `dcat:themeTaxonomy`
- removed `keyword`, `theme`, `endPointUrl`, `startDate`, and `endDate` (they are not mentioned in the corresponding table)
- fixed `fdp-o:metadataModified`
- added missing `foaf:homepage`
- removed unused `ContactPointShape`  

Other changes:

- use prefix `dcterms` instead of `dct` (easier to distinguish from`dcat` and also conforms to [prefixes used in DCAT])
  

fixes #31 

[prefixes used in DCAT]: https://www.w3.org/TR/vocab-dcat-3/#normative-namespaces